### PR TITLE
add stat json schema validator

### DIFF
--- a/tools/stat-validator.rb
+++ b/tools/stat-validator.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require "json-schema"
+require 'optparse'
+require_relative 'version'
+
+option = OptionParser.new do |option|
+    option.banner = 'Usage: stat-validator <file>'
+
+    option.on('-h', '--help', 'Print usage info') do
+        puts option
+        exit
+    end
+
+    option.on('-v', '--version', 'Print version info') do
+        puts "stat-validator #{StatValidator::VERSION}"
+        exit
+    end
+end
+
+option.parse!
+
+filename =
+    if ARGV == []
+        puts option
+        exit
+    else
+        ARGV[0]
+    end
+schema_path = File.dirname(__FILE__) + '/../statJsonSchema.json'
+
+puts JSON::Validator.fully_validate(schema_path, filename, :uri => true)

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -1,0 +1,3 @@
+module StatValidator
+  VERSION = '0.1'
+end


### PR DESCRIPTION
example  usage:
```ruby
$ ruby stat-validator.rb /c/Users/Ilya/Documents/tmp.txt
The property '#/' did not contain a required property of 'statVersion' in schema file:///Users/Ilya/RubymineProjects/statJsonValidator/statJsonSchema.json
The property '#/findings/0/location' did not contain a required property of 'path' in schema file:///Users/Ilya/RubymineProjects/statJsonValidator/statJsonSchema.json#
```
silence for no errors case